### PR TITLE
Update "Differences" page namespaces section

### DIFF
--- a/content/about/differences.adoc
+++ b/content/about/differences.adoc
@@ -194,19 +194,27 @@ Namespaces in ClojureScript are compiled to Google Closure namespaces which are 
 
 * You must currently use the `ns` form only with the following caveats
 ** You must use the `:only` form of `:use`
-** `:require` supports `:as` and `:refer`
+** `:require` supports `:as`, `:refer`, and `:rename`
 *** both options can be skipped
 *** in this case a symbol can be used as a libspec directly
-**** * that is, `(:require lib.foo)` and `(:require [lib.foo])` are both supported and mean the same thing
+**** that is, `(:require lib.foo)` and `(:require [lib.foo])` are both supported and mean the same thing
+*** `:rename` specifies a map from referred var names to different symbols (and can be used to prevent clashes)
 *** http://clojure.github.io/clojure/clojure.core-api.html#clojure.core/require[prefix lists] are not supported
-** The only option for `:refer-clojure` is `:exclude`
+** The only options for `:refer-clojure` are `:exclude` and `:rename`
 ** `:import` is available only for importing Google Closure classes
-*** ClojureScript types and records should be brought in with `:use` or `:require :refer`, not `:import`ed
+*** ClojureScript types and records should be brought in with `:use` or `:require :refer`, not `:import` ed
 * Macros must be defined in a different _compilation stage_ than the one from 
 where they are consumed. One way to achieve this is to define them in one namespace and use them from another. They are referenced via the `:require-macros` / `:use-macros` options to `ns`
 ** `:require-macros` and `:use-macros` support the same forms that `:require` and `:use` do
 
-_Implicit macro loading_: If a namespace is required or used, and that namespace _itself_ requires or uses macros from its own namespace, then the macros will be implicitly required or used using the same specifications. This oftentimes leads to simplified library usage, such that the consuming namespace need not be concerned about explicitly distinguishing between whether certain vars are functions or macros.
+_Implicit macro loading_: If a namespace is required or used, and that namespace itself requires or uses macros from its own namespace, then the macros will be implicitly required or used using the same specifications. Furthermore, in this case, macro vars may be included in a `:refer` or `:only` spec. This oftentimes leads to simplified library usage, such that the consuming namespace need not be concerned about explicitly distinguishing between whether certain vars are functions or macros. For example:
+
+[source,clojure]
+----
+(ns testme.core (:require [cljs.test :as test :refer [test-var deftest]]))
+----
+
+will result in `test/is` resolving properly, along with the `test-var` function and the deftest macro being available unqualified.
 
 _Inline macro specification_: As a convenience, `:require` can be given either `:include-macros true` or `:refer-macros
 [syms...]`. Both desugar into forms which explicitly load the matching Clojure file containing macros. (This works independently of whether the namespace being required internally requires or uses its own macros.) For example:
@@ -227,6 +235,20 @@ is sugar for
             [woz.core :as woz :refer [woz-fn]])
   (:require-macros [foo.core :as foo]
                    [woz.core :as woz :refer [apple jax]]))
+----
+
+_Auto-aliasing clojure namespaces_: If a non-existing `clojure.\*` namespace is required or used and a matching `cljs.*` namespace exists, the `cljs.\*` namespace will be loaded and an alias will be automatically established from the `clojure.*` namespace to the `cljs.*` namespace. For example:
+
+[source,clojure]
+----
+(ns testme.core (:require [clojure.test]))
+----
+
+will be automatically converted to
+
+[source,clojure]
+----
+(ns testme.core (:require [cljs.test :as clojure.test]))
 ----
 
 == Libs


### PR DESCRIPTION
Catch up with latest language features as documented on the original Wiki prior to the creation of the ClojureScript site.