### PR TITLE
Update QuickStart link to released 1.9.216 JAR

### DIFF
--- a/content/guides/quick-start.adoc
+++ b/content/guides/quick-start.adoc
@@ -12,7 +12,7 @@ toc::[]
 The only dependencies required for this tutorial are an installation of
 http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html[Java
 8] and the
-https://github.com/clojure/clojurescript/releases/download/r1.9.89/cljs.jar[standalone
+https://github.com/clojure/clojurescript/releases/download/r1.9.216/cljs.jar[standalone
 ClojureScript JAR]. ClojureScript itself only requires Java 7 but the
 standalone JAR comes bundled with useful
 http://www.oracle.com/technetwork/articles/java/jf14-nashorn-2126515.html[Nashorn]


### PR DESCRIPTION
(Missed one of the two links in the previous PR.)