### PR TITLE
Fix bug onMouseOver event in source-highlight box

### DIFF
--- a/content/reference/dependencies.adoc
+++ b/content/reference/dependencies.adoc
@@ -109,7 +109,7 @@ advanced optimizations. Try compiling the same code with
 an error message similar to the following (it may not be exactly as
 below):
 
-[source]
+[source,javascript]
 ----
 Uncaught TypeError: sa.B is not a function
 ----


### PR DESCRIPTION
Missing Javascript type in source-highlight causing a bug on the dependencies section. Tests for chrome and firefox.