### PR TITLE
Corrected links to dependencies

### DIFF
--- a/content/guides/quick-start.adoc
+++ b/content/guides/quick-start.adoc
@@ -654,7 +654,7 @@ work.
 
 ClojureScript supports a wide variety of options for including
 ClojureScript and JavaScript dependencies (see
-[link:#dependencies[Dependencies]] for details). However the simplest
+http://clojurescript.org/reference/dependencies[Dependencies] for details). However the simplest
 approach is to include a properly packaged JAR on the classpath.
 http://cljsjs.github.io[CLJSJS] provides a nice set of curated
 JavaScript libraries that suffices to demonstrate how dependencies are
@@ -706,7 +706,7 @@ java -cp 'cljs.jar:lib/*:src' clojure.main build.clj
 
 As your dependency graph becomes more sophisticated it may make sense to
 rely on Maven or Leiningen to manage dependencies for you. Please refer
-to [link:#dependencies[Dependencies]] for a comprehensive tutorial. What
+to http://clojurescript.org/reference/dependencies[Dependencies] for a comprehensive tutorial. What
 follows is just the basics.
 
 [[leiningen]]


### PR DESCRIPTION
I believe you wanted the links to point to http://clojurescript.org/reference/dependencies as pointing to basically themselves doesn't seem very helpful.