### PR TITLE
Replace `export let` with `export var`

### DIFF
--- a/content/guides/javascript-modules.adoc
+++ b/content/guides/javascript-modules.adoc
@@ -142,7 +142,7 @@ Edit this file to look like the following:
 
 [source,javascript]
 ----
-export let sayHello = function() {
+export var sayHello = function() {
     console.log("Hello, world!");
 };
 ----
@@ -206,10 +206,10 @@ Without quitting your REPL, edit `src/js/hello.js` to the following:
 
 [source,javascript]
 ----
-export let sayHello = function() {
+export var sayHello = function() {
     console.log("Hello, world!");
 };
-export let sayThings = function(xs) {
+export var sayThings = function(xs) {
     for(let x of xs) {
         console.log(x);
     }
@@ -298,15 +298,15 @@ Let's add a React JSX component to `src/js/hello.js`:
 
 [source,javascript]
 ----
-export let sayHello = function() {
+export var sayHello = function() {
     console.log("Hello, world!");
 };
-export let sayThings = function(xs) {
+export var sayThings = function(xs) {
     for(let x of xs) {
         console.log(x);
     }
 };
-export let reactHello = function() {
+export var reactHello = function() {
     return <div>Hello world!</div>
 };
 ----


### PR DESCRIPTION
When running through the `(require '[js.hello :as hello] :reload)` example, I got an error message from Node:

> SyntaxError: Identifier 'sayHello$$module$src$js$hello' has already been declared
>     at /home/rei/repos/hello-es6/.cljs_node_repl/src/js/hello.js:1:1
>     at ContextifyScript.Script.runInThisContext (vm.js:26:33)
>     at Object.exports.runInThisContext (vm.js:79:17)
>     at nodeGlobalRequire (repl:85:6)
>     at global.CLOSURE_IMPORT_SCRIPT (repl:75:3)
>     at Object.goog.require (repl:21:8)
>     at repl:1:6
>     at ContextifyScript.Script.runInThisContext (vm.js:26:33)
>     at Object.exports.runInThisContext (vm.js:79:17)
>     at Domain.<anonymous> ([stdin]:50:34)

This was due to the fact that Node (my version is 7.4.0) disallows redefinining anything declared with a `let`.  Cf: https://github.com/nodejs/node/issues/6118, https://github.com/nodejs/node/issues/8441

This commit replace any `export let` with an `export var` which can be refined without error.