### PR TITLE
Update bad reference to non-existent out/main.js file

### DIFF
--- a/content/guides/javascript-modules.adoc
+++ b/content/guides/javascript-modules.adoc
@@ -153,7 +153,7 @@ Let's check that our watch script works:
 lein trampoline run -m clojure.main watch.clj
 ----
 
-You can verify the script works as intended by invoking Node on `out/main.js`:
+You can verify the script works as intended by invoking `node main.js` from the project's root:
 
 ----
 node main.js


### PR DESCRIPTION
While following along I got tripped up on the step where you 'invoke Node on `out/main.js`' because my main file was in the root of the directory. This updates the instruction so that it is consistent with the rest of the guide.