### PR TITLE
Change Liveops Cloud to Serenova

### DIFF
--- a/content/community/companies.adoc
+++ b/content/community/companies.adoc
@@ -63,7 +63,6 @@ Below is a partial list of some companies using ClojureScript.
 * https://kirasystems.com[Kira Systems]
 * https://lifebooker.com[Lifebooker]
 * http://lightmesh.com[LightMesh]
-* http://liveopscloud.com[LiveOps Cloud]
 * https://www.loyal3.com/[Loyal3] (only certain parts of public site, transition in progress)
 * http://www.mttmarket.com/[MTTMarket]
 * http://www.mastodonc.com/[Mastodon C] (Not on public site, however)
@@ -103,6 +102,7 @@ Below is a partial list of some companies using ClojureScript.
 * https://www.repairtechsolutions.com/[RepairTech]
 * http://www.roomstorm.com[Roomstorm]
 * http://scivera.com[SciVera] (Not on public site, however)
+* http://serenova.com[Serenova]
 * http://www.shareablee.com[Shareablee]
 * http://www.sinapsi.com/[Sinapsi]
 * http://sistemimoderni.com[Sistemi Moderni]


### PR DESCRIPTION
Liveops Cloud has rebranded to Serenova (but we still use ClojureScript)