### PR TITLE
Update "Bootstrapping the Compiler" page

### DIFF
--- a/content/reference/bootstrapping.adoc
+++ b/content/reference/bootstrapping.adoc
@@ -27,12 +27,14 @@ ClojureScript JVM (varying perf between engines).
 * https://github.com/tahmidsadik112/Replicator[Android REPL: Replicator]
 * https://github.com/mfikes/planck[OS X REPL: Planck]
 * http://jellea.github.io/QuilFiddle/[QuilFiddle]
-* http://session-repl.com[SessionRepl]
 * http://roman01la.github.io/threejs-cljs-playground/[Threejs
 playground]
 * https://github.com/ScalaConsultants/replumb[Library for bootstrapped
 REPLs: Replumb]
 * http://crepl.thegeez.net[crepl: collaborative repl]
+* https://github.com/anmonteiro/lumo[Desktop REPL: Lumo]
+* https://github.com/viebel/klipse[Embeddable clojurescript repl: KLIPSE]
+* http://ctford.github.io/klangmeister[Musical live coding environment: Klangmeister]
 
 The following enumerates the remaining tasks:
 


### PR DESCRIPTION
- Remove broken link for SessionRepl - I couldn't find anything that made sense to replace it with on Google, though it may be out there
- Add Lumo, Klipse, and Klangmeister (these existed on the Github wiki but not here)