### PR TITLE
Update 'rlwarp' usage necessity in QuickStart site

### DIFF
--- a/content/guides/quick-start.adoc
+++ b/content/guides/quick-start.adoc
@@ -342,7 +342,7 @@ for Node.js, Rhino, Nashorn, and browsers.
 Let's hook up a browser REPL to our project.
 
 First it is recommended (but not required) that you install
-https://github.com/hanslub42/rlwrap[rlwrap].
+https://github.com/hanslub42/rlwrap[rlwrap]. Under OS X the easiest way is to use http://brew.sh[brew] and `brew install rlwrap`.
 
 Let's create a REPL script `repl.clj`:
 

--- a/content/guides/quick-start.adoc
+++ b/content/guides/quick-start.adoc
@@ -341,9 +341,8 @@ for Node.js, Rhino, Nashorn, and browsers.
 
 Let's hook up a browser REPL to our project.
 
-First it is recommended that you install
-http://utopia.knoware.nl/~hlub/uck/rlwrap/[rlwrap]. Under OS X the
-easiest way is to use http://brew.sh[brew] and `brew install rlwrap`.
+First it is recommended (but not required) that you install
+https://github.com/hanslub42/rlwrap[rlwrap].
 
 Let's create a REPL script `repl.clj`:
 
@@ -397,6 +396,11 @@ development and we don't want multiple connection instances.
 
 Let's try it:
 
+[source,clojure]
+----
+java -cp cljs.jar:src clojure.main repl.clj
+----
+or
 [source,clojure]
 ----
 rlwrap java -cp cljs.jar:src clojure.main repl.clj


### PR DESCRIPTION
Explicit notice that `rlwrap` is not required
Also `brew install rlwrap` is broken