### PR TITLE
Update list of compiler warnings

### DIFF
--- a/content/reference/compiler-options.adoc
+++ b/content/reference/compiler-options.adoc
@@ -410,6 +410,7 @@ with associated booleans. Defaults to true.
 The following warnings are supported:
 
 * `:preamble-missing`, missing preamble
+* `:unprovided`, required namespace not provided
 * `:undeclared-var`, undeclared var
 * `:undeclared-ns`, var references non-existent namespace
 * `:undeclared-ns-form`, namespace reference in ns form that does not
@@ -431,7 +432,17 @@ exist
 * `:protocol-invalid-method`, protocol method does not match declaration
 * `:protocol-duped-method`, duplicate protocol method implementation
 * `:protocol-multiple-impls`, protocol implemented multiple times
+* `:protocol-with-variadic-method`, protocol declares variadic signature
+* `:protocol-impl-with-variadic-method`, protocol impl employs variadic signature
+* `:protocol-impl-recur-with-target`, target passed in recur to protocol method head
 * `:single-segment-namespace`, single segment namespace
+* `:munged-namespace`, namespace name contains a reserved JavaScript keyword
+* `:ns-var-clash`, namespace clashes with var
+* `:extend-type-invalid-method-shape`, method arities must be grouped together
+* `:unsupported-js-module-type`, unsupported JavaScript module type
+* `:unsupported-preprocess-value`, unsupported foreign lib preprocess value
+* `:js-shadowed-by-local`, name shadowed by a local
+* `:infer-warning`, warnings related to externs inference
 
 [[elide-asserts]]
 === :elide-asserts


### PR DESCRIPTION
Includes `:protocol-impl-recur-with-target`, which is slated for the next release