### PR TITLE
Adds Workframe to companies list

### DIFF
--- a/content/community/companies.adoc
+++ b/content/community/companies.adoc
@@ -123,6 +123,7 @@ Below is a partial list of some companies using ClojureScript.
 * http://www.uswitch.com[uSwitch]
 * https://www.vincit.com[Vincit]
 * http://vitallabs.co[Vital Labs]
+* https://workframe.com[Workframe]
 * http://yetanalytics.com[Yet Analytics]
 * http://xnlogic.com[XN Logic]
 * http://zensight.co/[Zensight]


### PR DESCRIPTION
Proposing this change to the companies page. Workframe uses a full-stack Clojure stack. We are naced in NYC and I am the CTO and one of the founders.