### PR TITLE
Add :checked-arrays and :invalid-array-access

### DIFF
--- a/content/reference/compiler-options.adoc
+++ b/content/reference/compiler-options.adoc
@@ -375,6 +375,22 @@ defaults to `true`.
 :recompile-dependents false
 ----
 
+[[checked-arrays]]
+=== :checked-arrays
+
+If set to `:warn` or `:error`, checks inferred types and runtime values
+passed to `aget` and `aset`. Inferred type mismatches will result in
+the `:invalid-array-access` warning being triggered. Logs when incorrect 
+values are passed if set to `:warn`, throws if set to `:error`. May be
+set to a `false`-y value to disable this feature.
+
+This setting does not apply if `:optimizations` is set to `:advanced`.
+
+[source,clojure]
+----
+:checked-arrays :warn
+----
+
 [[static-fns]]
 === :static-fns
 
@@ -443,6 +459,7 @@ exist
 * `:extending-base-js-type`, JavaScript base type extension
 * `:invoke-ctor`, type constructor invoked as function
 * `:invalid-arithmetic`, invalid arithmetic
+* `:invalid-array-access`, invalid use of `aget` or `aset`
 * `:protocol-invalid-method`, protocol method does not match declaration
 * `:protocol-duped-method`, duplicate protocol method implementation
 * `:protocol-multiple-impls`, protocol implemented multiple times


### PR DESCRIPTION
Also, since these default to off, use this as an opportunity to illustrate how to enable a warning.
This change should not be merged until the next compiler is released (these are currently in master).