### PR TITLE
Add :closure-output-charset

### DIFF
--- a/content/reference/compiler-options.adoc
+++ b/content/reference/compiler-options.adoc
@@ -597,6 +597,25 @@ Defaults to `:ecmascript3`
 :language-out :ecmascript3
 ----
 
+[[closure-output-charset]]
+=== :closure-output-charset
+
+Configure the output character set. May be:
+
+* `iso-8859-1`
+* `us-ascii`
+* `utf-16`
+* `utf-16be`
+* `utf-16le`
+* `utf-8`
+
+Defaults to `utf-8`
+
+[source,clojure]
+----
+:closure-output-charset "iso-8859-1"
+----
+
 [[rewrite-polyfills]]
 === :rewrite-polyfills
 


### PR DESCRIPTION
Ref https://github.com/clojure/clojurescript/blob/master/src/main/clojure/cljs/closure.clj#L257 and https://github.com/clojure/clojurescript/blob/master/src/main/clojure/cljs/closure.clj#L171

Found this by reading the closure.clj source as needed to output a ISO-8859-1 file instead of Unicode for loading compiled JavaScript into LDAP.