### PR TITLE
Fixed entries in code splitting guide

### DIFF
--- a/content/guides/code-splitting.adoc
+++ b/content/guides/code-splitting.adoc
@@ -57,9 +57,9 @@ Edit this script to look like the following:
    :output-dir "out"
    :asset-path "/out"
    :optimizations :none
-   :modules {:foo {:entries '#{foo.core}
+   :modules {:foo {:entries #{"foo.core"}
                    :output-to "out/foo.js"}
-             :bar {:entries '#{bar.core}
+             :bar {:entries #{"bar.core"}
                    :output-to "out/bar.js"}}
    :browser-repl true
    :verbose true})
@@ -179,9 +179,9 @@ Make it look like the following:
    :asset-path "/out"
    :optimizations :advanced
    :verbose true
-   :modules {:foo {:entries '#{foo.core}
+   :modules {:foo {:entries #{"foo.core"}
                    :output-to "out/foo.js"}
-             :bar {:entries '#{bar.core}
+             :bar {:entries #{"bar.core"}
                    :output-to "out/bar.js"}}})
 
 (System/exit 0)


### PR DESCRIPTION
After beating my head against the wall, I read the source...seems like this changed from symbols to strings?