### PR TITLE
Eliminate language implying `:npm-deps` installs

### DIFF
--- a/content/reference/compiler-options.adoc
+++ b/content/reference/compiler-options.adoc
@@ -318,7 +318,7 @@ quoted.
 === :npm-deps
 
 Declare NPM dependencies. A map of NPM package names to the desired versions.
-Used to install NPM dependencies on behalf of the user. See also `:install-deps`.
+See also `:install-deps`.
 
 [source,clojure]
 ---


### PR DESCRIPTION
It used to install, but the `:install-deps` flag controls that.