### PR TITLE
Fix formatting of NPM deps example

### DIFF
--- a/content/reference/compiler-options.adoc
+++ b/content/reference/compiler-options.adoc
@@ -321,9 +321,9 @@ Declare NPM dependencies. A map of NPM package names to the desired versions.
 See also `:install-deps`.
 
 [source,clojure]
----
-{:npm-deps {"lodash" "4.17.4}}
----
+----
+:npm-deps {"lodash" "4.17.4}
+----
 
 [[install-deps]]
 === :install-deps


### PR DESCRIPTION
* Add an extra dash to indicate code
* Just provide the key and value like other examples