### PR TITLE
Nothing in the docs says that a module that is being *loaded* needs t…

### DIFF
--- a/content/guides/code-splitting.adoc
+++ b/content/guides/code-splitting.adoc
@@ -131,6 +131,7 @@ touch src/bar/core.clj
 
 ```
 (ns bar.core
+  ; IMPORTANT: You have to require cljs.loader in modules, even if you don't directly make calls to it.
   (:require [cljs.loader :as loader]))
 
 (enable-console-print!)


### PR DESCRIPTION
…o require the loader.

The code shows it being required, but this is easy to overlook as cruft that was accidental since the namespace isn't actually used. This means that library loading side-effect is needed for things to work properly, and should be more carefully documented.