### PR TITLE
Correct ns form in testing example

### DIFF
--- a/content/tools/testing.adoc
+++ b/content/tools/testing.adoc
@@ -20,7 +20,7 @@ following:
 [source,clojure]
 ----
 (ns my-project.tests
-  (:require [cljs.test :refer-macros [deftest is testing run-tests]]))
+  (:require-macros [cljs.test :refer [deftest is are testing]]))
 ----
 
 [[writing-tests]]


### PR DESCRIPTION
Otherwise, you get this error:

> Exception in thread "main" clojure.lang.ExceptionInfo: Only :as, :refer and :rename options supported in :require / :require-macros; offending spec: [cljs.test :require-macros [deftest is are testing]]