### PR TITLE
newer Clojurescript version

### DIFF
--- a/content/guides/javascript-modules.adoc
+++ b/content/guides/javascript-modules.adoc
@@ -68,7 +68,7 @@ Edit the `project.clj` file to look like the following:
 ----
 (defproject hello-es6 "0.1.0-SNAPSHOT"
   :dependencies [[org.clojure/clojure "1.9.0-alpha14"]
-                 [org.clojure/clojurescript "1.9.854"]]
+                 [org.clojure/clojurescript "1.9.908"]]
   :jvm-opts ^:replace ["-Xmx1g" "-server"])
 ----
 


### PR DESCRIPTION
The project doesn't build if you use version stated in the guide. With this newer version it all works.

https://github.com/clojure/clojurescript-site/issues/143