### PR TITLE
Minor tweak to JavaScript API introduction

### DIFF
--- a/content/reference/javascript-api.adoc
+++ b/content/reference/javascript-api.adoc
@@ -9,8 +9,10 @@ ifdef::env-github,env-browser[:outfilesuffix: .adoc]
 
 toc::[]
 
-ClojureScript defines types that have stable, publicly-consumable
-JavaScript APIs as specified below.
+The implementation of ClojureScript collections define several JavaScript functions
+that can be called from ClojureScript using JavaScript interop or directly from
+JavaScript.  This page describes those functions which are officially stable and 
+publicly-consumable.
 
 [[indexOf]]
 === indexOf


### PR DESCRIPTION
I found it confusing that this described the "JavaScript API" and then all the examples were in ClojureScript.  I also found referring to "ClojureScript types" a little confusing.  Hopefully this conveys the intent.