### PR TITLE
Change run-clojure to inf-clojure.

### DIFF
--- a/content/tools/emacs-inf.adoc
+++ b/content/tools/emacs-inf.adoc
@@ -24,7 +24,7 @@ Edit your `.emacs` or `init.el` and add a function like the following if you are
 ----
 (defun cljs-node-repl ()
   (interactive)
-  (run-clojure "java -cp cljs.jar clojure.main repl.clj"))
+  (inf-clojure "java -cp cljs.jar clojure.main repl.clj"))
 ----
 
 If you are using Leiningen:
@@ -33,7 +33,7 @@ If you are using Leiningen:
 ----
 (defun cljs-node-repl ()
   (interactive)
-  (run-clojure "lein trampoline run -m clojure.main repl.clj"))
+  (inf-clojure "lein trampoline run -m clojure.main repl.clj"))
 ----
 
 Open your ClojureScript file and run `M-x cljs-node-repl`. You'll get a new buffer with the REPL. Switch back to your file and run `M-x inf-clojure-minor-mode`. `C-c C-l` will load the file. `C-c Meta-n` will switch your namespace. If you place your cursor at the end of a s-expression, `C-x C-e` will evaluate that expression. `C-c C-v` will show the docs. `C-c C-s` will show the source. `C-c <return>` will macroexpand. Refer to https://github.com/clojure-emacs/inf-clojure[inf-clojure] for more documentation.


### PR DESCRIPTION
run-clojure was an alias for inf-clojure, but it was removed in version 2.0 of inf-clojure. See the last bullet point in the Changes section: https://github.com/clojure-emacs/inf-clojure/releases/tag/v2.0.0