### PR TITLE
Add brief instructions on how to add a company to Companies

### DIFF
--- a/content/community/companies.adoc
+++ b/content/community/companies.adoc
@@ -5,7 +5,7 @@ David Nolen
 :toc: macro
 :icons: font
 
-Below is a partial list of some companies using ClojureScript. 
+Below is a partial list of some companies using ClojureScript. To add your company to the list, please submit a pull request to the https://github.com/clojure/clojurescript-site[ClojureScript.org repository].
 
 * http://www.8thlight.com[8th Light]
 * http://www.active-group.de/[Active Group]


### PR DESCRIPTION
This is frequently a page that people want to update, so they shouldn't have to go elsewhere to find out how to do it.