### PR TITLE
Add binding breaking change to 1.10.439 Release Notes

### DIFF
--- a/content/news/2018-11-02-release.adoc
+++ b/content/news/2018-11-02-release.adoc
@@ -131,6 +131,35 @@ WARNING: cljs.core/+, all arguments must be numbers, got [number string] instead
 Previously, without a type hint on `foo`, the compiler would produce a 
 warning that indicates a type of `any` instead of `number`.
 
+## Matching Clojure binding semantics
+
+The `binding` macro does not support referring to other bindings in `init-expr`. This is **breaking** change following in Clojure's footsteps.
+
+[source,clojure]
+----
+;; ClojureScript 1.10.339
+cljs.user=> (def ^:dynamic *a*)
+#'cljs.user/*a*
+cljs.user=> (def ^:dynamic *b*)
+#'cljs.user/*b*
+cljs.user=> (binding [*a* 1
+       #_=>           *b* (+ 1 *a*)]
+       #_=>   (println "B is" *b*))
+B is 2
+nil
+
+;; ClojureScript 1.10.439
+cljs.user=> (def ^:dynamic *a*)
+#'cljs.user/*a*
+cljs.user=> (def ^:dynamic *b*)
+#'cljs.user/*b*
+cljs.user=> (binding [*a* 1
+       #_=>           *b* (+ 1 *a*)]
+       #_=>   (println "B is" *b*))
+B is ##NaN
+nil
+----
+
 ## Graal.JS REPL Environment
 
 ClojureScript now ships with a Graal.JS REPL environment. This is a new Java-based REPL


### PR DESCRIPTION
Opening this PR in order to warn in the Release Notes that the behavior of `bindings` has changed in a breaking way.

One affected library is [`humane-test-output`](https://github.com/pjstadig/humane-test-output/issues/37).
