### PR TITLE
Add Clojurians-Zulip

### DIFF
--- a/content/community/resources.adoc
+++ b/content/community/resources.adoc
@@ -46,10 +46,8 @@ View & more…)
 === Chat
 
 * IRC: `#clojurescript` on https://freenode.net/[freenode.net]
-* Slack: `#clojurescript` on http://clojurians.slack.com/[clojurians]
-* http://clojurians.net/[you can get invite here]
-* http://clojurians-log.mantike.pro/clojurescript/index.html[searchable
-chat logs]
+* Slack: `#clojurescript` on http://clojurians.slack.com/[Clojurians Slack] (http://clojurians.net/[get an invite here])
+* http://clojurians-log.mantike.pro/clojurescript/index.html[searchable chat logs]
 * Zulip: `#clojurescript` on https://clojurians.zulipchat.com/#narrow/stream/151762-clojurescript[Clojurians Zulip Chat]
 
 [[mailing-lists]]

--- a/content/community/resources.adoc
+++ b/content/community/resources.adoc
@@ -50,6 +50,7 @@ View & more…)
 * http://clojurians.net/[you can get invite here]
 * http://clojurians-log.mantike.pro/clojurescript/index.html[searchable
 chat logs]
+* Zulip: `#clojurescript` on https://clojurians.zulipchat.com/#narrow/stream/151762-clojurescript[Clojurians Zulip Chat]
 
 [[mailing-lists]]
 === Mailing Lists

--- a/content/community/resources.adoc
+++ b/content/community/resources.adoc
@@ -47,7 +47,7 @@ View & more…)
 
 * IRC: `#clojurescript` on https://freenode.net/[freenode.net]
 * Slack: `#clojurescript` on http://clojurians.slack.com/[Clojurians Slack] (http://clojurians.net/[get an invite here])
-* http://clojurians-log.mantike.pro/clojurescript/index.html[searchable chat logs]
+** searchable chat logs can be found https://clojurians.zulipchat.com/#narrow/stream/180378-slack-archive/topic/clojurescript[here], and https://clojurians-log.clojureverse.org/[here]
 * Zulip: `#clojurescript` on https://clojurians.zulipchat.com/#narrow/stream/151762-clojurescript[Clojurians Zulip Chat]
 
 [[mailing-lists]]


### PR DESCRIPTION
This PR adds #clojurescript@Clojurians-Zulip to the chat-section.
Also added the searchable slack-archive on Zulip.

(Separate commits to allow for cherry-picking).