### PR TITLE
Fix dead links to Closure Library API, add Glögi

### DIFF
--- a/content/reference/google-closure-library.adoc
+++ b/content/reference/google-closure-library.adoc
@@ -32,19 +32,22 @@ code also serves as good examples of how to use Closure directly.
 |=======================================================================
 |ClojureScript wrapper |Closure Libraries
 |https://github.com/andrewmcveigh/cljs-time[cljs-time]
-|http://google.github.io/closure-library/api/namespace_goog_date.html[goog.date]
+|https://google.github.io/closure-library/api/goog.date.html[goog.date]
 
 |https://github.com/r0man/cljs-http[cljs-http]
-|http://google.github.io/closure-library/api/namespace_goog_net.html[goog.net],
-http://google.github.io/closure-library/api/class_goog_Uri.html[goog.uri]
+|https://google.github.io/closure-library/api/goog.net.XhrIo.html[goog.net.XhrIo],
+https://google.github.io/closure-library/api/goog.Uri.html[goog.uri]
 
 |https://github.com/JulianBirch/cljs-ajax[cljs-ajax]
-|http://google.github.io/closure-library/api/namespace_goog_net.html[goog.net],
-http://google.github.io/closure-library/api/class_goog_Uri.html[goog.uri],
-http://google.github.io/closure-library/api/namespace_goog_json.html[goog.json]
+|http://google.github.io/closure-library/api/goog.net.XhrIo.html[goog.net.XhrIo],
+http://google.github.io/closure-library/api/goog.Uri.html[goog.uri],
+http://google.github.io/closure-library/api/goog.json.html[goog.json]
 
 |https://funcool.github.io/cuerdas/latest/[cuerdas]
-|http://google.github.io/closure-library/api/namespace_goog_string.html[goog.string]
+|https://google.github.io/closure-library/api/goog.string.html[goog.string]
+
+|https://github.com/lambdaisland/glogi[glögi]
+|https://google.github.io/closure-library/api/goog.log.html[goog.log]
 |=======================================================================
 
 _* included in ClojureScript's core library_


### PR DESCRIPTION
The links to Google Closure Library namespaces and classes API docs have changed, update the Google Closure Library document to use the new links.

Add Glögi to the table of wrapper libraries, as an alternative to using goog.log directly.