### PR TITLE
Fix Shadow CLJS template section link

### DIFF
--- a/content/guides/project-templates.adoc
+++ b/content/guides/project-templates.adoc
@@ -40,7 +40,7 @@ with support for Reagent
 * https://github.com/pandeiro/jamal[jamal] Basic ClojureScript frontend repo with testing using Boot
 * https://github.com/Deraen/saapas[saapas] A complete frontend and backend example using Boot
 
-[[Shadow CLJS]]
+[[shadow-cljs]]
 == Shadow CLJS
 
 * https://github.com/filipesilva/create-cljs-app[create-cljs-app] Set up a modern CLJS web app by running one command.


### PR DESCRIPTION
It's not showing up correctly because the link must not include spaces.

![image](https://user-images.githubusercontent.com/4172079/67853092-b31de580-fb05-11e9-94b5-ccd534ad6296.png)


Followup to https://github.com/clojure/clojurescript-site/pull/328