### PR TITLE
redundant 'out' directory in webpack.config.js

### DIFF
--- a/content/guides/webpack.adoc
+++ b/content/guides/webpack.adoc
@@ -61,7 +61,7 @@ module.exports = {
   entry: './out/index.js',
   output: {
     path: __dirname + "/out",
-    filename: 'out/main.js'
+    filename: 'main.js'
   }
 }
 ```


### PR DESCRIPTION
main.js was being compiled to 'out/out/main.js'