### PR TITLE
Remove unnecessary webpack.config.js from guide

### DIFF
--- a/content/guides/webpack.adoc
+++ b/content/guides/webpack.adoc
@@ -53,22 +53,6 @@ Add webpack and its command line tools:
 npm install --save-dev webpack webpack-cli
 ```
 
-Create a `webpack.config.js` file:
-
-[source,javascript]
-```
-module.exports = {
-  entry: './out/index.js',
-  output: {
-    path: __dirname + "/out",
-    filename: 'main.js'
-  }
-}
-```
-
-The bundler will use our ClojureScript output file as the entry. We'll write
-the bundler result back into the output directory.
-
 We're now ready to setup our JS dependencies.
 
 [[javascript-dependencies]]
@@ -103,13 +87,14 @@ a `build.edn` file with the following:
  :output-to "out/index.js"
  :output-dir "out"
  :target :bundle
- :bundle-cmd {:none ["npx" "webpack" "--mode=development"]
-              :default ["npx" "webpack"]}
+ :bundle-cmd {:none ["npx" "webpack" "out/index.js" "-o" "out/main.js" "--mode=development"]
+              :default ["npx" "webpack" "out/index.js" "-o" "out/main.js"]}
  :closure-defines {cljs.core/*global* "window"}} ;; needed for advanced
 ```
 
 Our build will generate `out/index.js` which is exactly the entry file that
-Webpack is looking for.
+Webpack is looking for.  We'll write the bundler result back into the output
+directory.
 
 Note the new `:target :bundle` option. This ensures that the generated code
 is compatible with popular JavaScript bundlers that can handle Node.js style


### PR DESCRIPTION
This is not necessary, as the params we use can be passed from the
webpack CLI.  Webpack is now "zero config".

@dpsutton raised in slack that the webpack.config.js approach should be documented in order for users to progress to more complicated setups.

However, you can create a webpack.config.js without having to add the entry/output parameters back to the webpack.config.js.  The CLI arguments will be combined with those in webpack.config.js, this means you can simply copy/paste from the documentation on the webpack site in order to add complicated parts.