### PR TITLE
Fix the Contributor Agreement e-form link format

### DIFF
--- a/content/community/contributing.adoc
+++ b/content/community/contributing.adoc
@@ -96,9 +96,7 @@ web page listing authorized contributors that is accessible via a public URL.
 
 == Instructions for submitting the agreement
 
-* Fill out and submit the
-* https://secure.echosign.com/public/hostedForm?formid=95YMDL576B336E[Contributor
-* Agreement] (an online e-form)
+Fill out and submit the https://secure.echosign.com/public/hostedForm?formid=95YMDL576B336E[Contributor Agreement] (an online e-form).
 
 Please see the https://clojure.org/community/contributing[Contributing] page for
 a collection of resources on tickets, builds, patches, source, and more. If


### PR DESCRIPTION
### Context of the problem

The `Instructions for submitting the agreement` section of the [Contributing to ClojureScript](https://clojurescript.org/community/contributing) page has a format problem:

![image](https://user-images.githubusercontent.com/9122519/122147255-e9b98880-ce2e-11eb-9b9e-74f1cd881669.png)

### Context of the change

It formats the link and removes the bullet list. If the bullet list is needed/wanted, feel free to edit these changes!