### PR TITLE
Tools section

### DIFF
--- a/content/community/contributing_site.adoc
+++ b/content/community/contributing_site.adoc
@@ -79,7 +79,7 @@ When working on bigger changes it's useful to build the site locally. The site i
 
 To https://jbake.org/docs/2.5.0/#installation[install] JBake 2.5.0-SNAPSHOT:
 
-. `curl -O https://cdn.cognitect.com/clojurescript.org/jbake-2.5.0-SNAPSHOT-bin.zip` (or download this file with your browser)
+. `curl -O http://cdn.cognitect.com/clojurescript.org/jbake-2.5.0-SNAPSHOT-bin.zip` (or download this file with your browser)
 . `unzip -o jbake-2.5.0-SNAPSHOT-bin.zip`
 . Add jbake-2.5.0-SNAPSHOT/bin to your system PATH
 

--- a/content/tools/leinigen.adoc
+++ b/content/tools/leinigen.adoc
@@ -1,0 +1,13 @@
+= Leinigen
+Denis Baudinot
+2021-07-11
+:type: tools
+:toc: macro
+:icons: font
+
+https://leiningen.org/[Leinigen] is a build tool for Clojure and ClojureScript with an extensible plugin and template system.
+
+[[plugins]]
+== Plugins
+
+https://github.com/emezeske/lein-cljsbuild[lein-cljsbuild] provides ClojureScript compilation and file watching. For a more feature rich experience with browser hot reloading and CSS support head to https://github.com/bhauman/lein-figwheel[lein-figwheel].

--- a/content/tools/shadow-cljs.adoc
+++ b/content/tools/shadow-cljs.adoc
@@ -1,0 +1,13 @@
+= shadow-cljs
+Denis Baudinot
+2021-07-11
+:type: tools
+:toc: macro
+:icons: font
+
+https://github.com/thheller/shadow-cljs[shadow-cljs] compiles, watches, hot reloads ClojureScript projects and provides targets and integration within the larger JavaScript ecosystem such as Nodejs, NPM and browser modules. It can be used as a standalone npm package to be run from the command line and a Clojure library to be integrated with other build tooling.
+
+From the shadow-cljs https://shadow-cljs.github.io/docs/UsersGuide.html[user guide]:
+
+[quote]
+shadow-cljs provides everything you need to compile your ClojureScript projects with a focus on simplicity and ease of use. The provided build targets abstract away most of the manual configuration so that you only have to configure the essentials for your build. Each target provides optimal defaults for each environment and get an optimized experience during development and in release builds.

--- a/content/tools/vscode.adoc
+++ b/content/tools/vscode.adoc
@@ -1,0 +1,13 @@
+= Visual Studio Code
+Denis Baudinot
+2021-07-11
+:type: tools
+:toc: macro
+:icons: font
+
+https://code.visualstudio.com/[Visual Studio Code] has Clojure and ClojureScript support via the https://marketplace.visualstudio.com/items?itemName=betterthantomorrow.calva[Calva] extension.
+
+From the https://calva.io/[calva documentation]:
+
+[quote]
+Calva is an integrated REPL powered environment for enjoyable and productive Clojure and ClojureScript development in Visual Studio Code. It includes inline code evaluation, Paredit, code formatting, a test runner, syntax highlighting, linting, and more. Calva is open source and free to use.


### PR DESCRIPTION
In regards to this issue: https://github.com/clojure/clojurescript-site/issues/387

I added three pages in the tooling section. I think the added tools (vscode and shadow-cljs) warrant mention on the site.

Caveat: The individual pages are small. I specifically didn't use leinigen for ClojureScript for a long time.

To accommodate the changes I suggest to change the navigation like so under `tools.ftl`:

```html

<a href="vscode" class="w-nav-link clj-section-nav-item-link">Visual Studio Code</a>

<div class="w-nav-link clj-section-nav-heading">Build Tools</div>
<a href="leinigen" class="w-nav-link clj-section-nav-item-link">Leinigen</a>
<a href="shadow-cljs" class="w-nav-link clj-section-nav-item-link">shadow-cljs</a>

```