### PR TITLE
Fix anchor compiler-option global-goog-object&array

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -36,6 +36,8 @@ Retrieve and install the current theme assets (these don't change very often so 
 
 Generate the pages:
 
+ > Note that `jbake` 2.5.0 requires Java 8. (It will not run properly under Java 9.)
+
 . `jbake` - this will create the static site in the output directory
 . Run `jbake -s` to serve these pages at http://localhost:8820/index
 

--- a/content/reference/compiler-options.adoc
+++ b/content/reference/compiler-options.adoc
@@ -137,7 +137,7 @@ multimethod. For more info see <<xref/../javascript-library-preprocessing#,JavaS
 exported values. The keys may be symbols or strings. If present the foreign library can be used idiomatically
 when required, i.e. support for `:refer`, `:rename`, `:as`, etc.
 
-[[:global-goog-object&array]]
+[[global-goog-object-ampersand-array]]
 === :global-goog-object&array
 
 Defaults to `false`. If `true` load `goog.object` and `goog.array` as global


### PR DESCRIPTION
The ampersand in the compiler-option `global-goog-object&array` prevents the anchor from being rendered correctly:
```
[[:global-goog-object&array]] === :global-goog-object&array

Defaults to false. If true load goog.object and goog.array as global namespaces rather than as goog.module namespaces.
```