### PR TITLE
Remove deleted closure compiler warning options

### DIFF
--- a/content/reference/compiler-options.adoc
+++ b/content/reference/compiler-options.adoc
@@ -580,9 +580,7 @@ The following Closure warning options are exposed to ClojureScript:
 [source,clojure]
 ----
 :access-controls
-:ambiguous-function-decl
 :analyzer-checks
-:check-eventful-object-disposal
 :check-regexp
 :check-types
 :check-useless-code
@@ -596,14 +594,11 @@ The following Closure warning options are exposed to ClojureScript:
 :deprecated-annotations
 :duplicate-message
 :duplicate-vars
-:es3
 :es5-strict
 :externs-validation
 :extra-require
-:fileoverview-jsdoc
 :function-params
 :global-this
-:internet-explorer-checks
 :invalid-casts
 :j2cl-checks
 :jsdoc-missing-type


### PR DESCRIPTION
These checks are deleted from closure compiler used in latests versions of Clojurescript 
and lead to `NullPointerException`s if included in projects `:closure-warnings` configuration.

https://github.com/google/closure-compiler/wiki/Warnings#warnings-categories

I have considered to include comment on which version of ClojureScript & Closure Compiler an options was removed but feels like if it would not be worth the effort and complexity.