### PR TITLE
Revert Slack *invite* link to HTTP

### DIFF
--- a/content/community/resources.adoc
+++ b/content/community/resources.adoc
@@ -45,7 +45,7 @@ View & more…)
 === Chat
 
 * IRC: `#clojurescript` on https://freenode.net/[freenode.net]
-* Slack: `#clojurescript` on https://clojurians.slack.com/[Clojurians Slack] (https://clojurians.net/[get an invite here])
+* Slack: `#clojurescript` on https://clojurians.slack.com/[Clojurians Slack] (http://clojurians.net/[get an invite here])
 ** searchable chat logs can be found https://clojurians.zulipchat.com/#narrow/stream/180378-slack-archive/topic/clojurescript[here], and https://clojurians-log.clojureverse.org/[here]
 * Zulip: `#clojurescript` on https://clojurians.zulipchat.com/#narrow/stream/151762-clojurescript[Clojurians Zulip Chat]
 


### PR DESCRIPTION
Whilst Slack itself is HTTPS, the invite link is HTTP. This reverts the change from July 2021 that broke the invite link by changing it to HTTPS.