### PR TITLE
update cljsjs/react-dom to latest version available

### DIFF
--- a/content/guides/quick-start.adoc
+++ b/content/guides/quick-start.adoc
@@ -309,7 +309,7 @@ Modify your `deps.edn` file:
 [source,clojure]
 ----
 {:deps {org.clojure/clojurescript {:mvn/version "1.11.54"}
-        cljsjs/react-dom {:mvn/version "16.2.0-3"}}}
+        cljsjs/react-dom {:mvn/version "18.3.1-1"}}}
 ----
 
 Let's edit our simple program to look like the following so that React


### PR DESCRIPTION
Existing version of clsjs/react-dom (16.2.0-3) wasn't available to me, at least on some attempts to fetch via `clj -M --main cljs.main --compile hello-world.core --repl` (other times I tried, the version was available).

Anyway, the latest release in this change (`18.3.1-1`) works in my testing, so might as well keep current with it.

To find the latest available release, I looked here: https://clojars.org/cljsjs/react-dom