### PR TITLE
Update link for uix

### DIFF
--- a/content/community/libraries.adoc
+++ b/content/community/libraries.adoc
@@ -46,7 +46,7 @@ Clojure(Script) reader
 * https://github.com/r0man/sablono[sablono] Hiccup style wrapper for React DOM Elements
 * https://github.com/bhauman/cljs-react-reload[cljs-react-reload] Writing reloadable React Classes
 * https://github.com/Lokeh/helix[helix] Modern React development with low runtime overhead
-* https://roman01la.gitbook.io/uix[uix] Idiomatic interface into modern React
+* https://uix-cljs.dev/[uix] Idiomatic interface into modern React
 
 === HTML Templating
 


### PR DESCRIPTION
Pointed out on [Slack](https://clojurians.slack.com/archives/CNMR41NKB/p1742270509144139) that the link for uix is wrong