### PR TITLE
Update GitHub search query for cljs files

### DIFF
--- a/content/reference/google-closure-library.adoc
+++ b/content/reference/google-closure-library.adoc
@@ -157,7 +157,7 @@ You can look for `cljs` files on Github that use `goog.dom` with the
 following search:
 
 ----
-Search GitHub: "goog.dom extension:cljs"
+Search GitHub: "goog.dom path:*.cljs"
 ----
 
 Or you can search Google Closure Library on Github for keywords


### PR DESCRIPTION
Github updated its search query syntax when they rewrote the search backend to rust a while ago.